### PR TITLE
Renomeação da constante logomini e remoção de import desnecessário

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ O arquivo fica dessa forma
 ```dart
 class  AppImages {
 static  const logoFull = "assets/images/logofull.png";
-static  const logomini = "assets/images/logomini.png";
+static  const logoMini = "assets/images/logomini.png";
 static  const union = "assets/images/union.png";
 static  const person = "assets/images/person.png";
 static  const google = "assets/images/google.png";

--- a/lib/shared/themes/app_images.dart
+++ b/lib/shared/themes/app_images.dart
@@ -1,8 +1,6 @@
-import 'package:flutter/material.dart';
-
 class AppImages {
   static const logoFull = "assets/images/logofull.png";
-  static const logomini = "assets/images/logomini.png";
+  static const logoMini = "assets/images/logomini.png";
   static const union = "assets/images/union.png";
   static const person = "assets/images/person.png";
   static const google = "assets/images/google.png";


### PR DESCRIPTION
## Qual o problema inicial?
- A constante `logoFull` segue o padrão camelCase enquanto a constante `logomini` não segue.
- Import desnecessário do `material.dart`

## O que esse PR faz?
- Renomeia a constante `logomini` para `logoMini`.
- Remove o `import` desnecessário.